### PR TITLE
Update connection string examples.

### DIFF
--- a/newrelic_resque_agent/README.md
+++ b/newrelic_resque_agent/README.md
@@ -30,7 +30,7 @@ The Resque monitoring Plugin for New Relic requires the following:
  
     3.1. replace `YOUR_LICENSE_KEY_HERE` with your New Relic license key. Your license key can be found under Account Settings at https://rpm.newrelic.com, see https://newrelic.com/docs/subscriptions/license-key for more help.
 
-    3.2. add the Redis connection string: 'hostname:port' or 'hostname:port:db' or 'redis://user:password@hostname:port:db'
+    3.2. add the Redis connection string: 'hostname:port' or 'hostname:port:db' or 'redis://user:password@hostname:port' or 'redis://user:password@hostname:port/db'
 
 4. Execute
 

--- a/newrelic_resque_agent/config/newrelic_plugin.yml.example
+++ b/newrelic_resque_agent/config/newrelic_plugin.yml.example
@@ -21,12 +21,12 @@ newrelic:
 #
 agents:
   my_resque_1:
-    # Redis connection string: 'hostname:port' or 'hostname:port:db' or 'redis://user:password@hostname:port:db'
+    # Redis connection string: 'hostname:port' or 'hostname:port:db' or 'redis://user:password@hostname:port' or 'redis://user:password@hostname:port/db'
     redis: localhost:6379
     # Resque namespace
     namespace:
   my_resque_2:
-    # Redis connection string: 'hostname:port' or 'hostname:port:db' or 'redis://user:password@hostname:port:db'
+    # Redis connection string: 'hostname:port' or 'hostname:port:db' or 'redis://user:password@hostname:port' or 'redis://user:password@hostname:port/db'
     redis: localhost:6379
     # Resque namespace
     namespace:


### PR DESCRIPTION
The example described newrelic_plugin.yml and the readme indicate you can use the connection the string `redis://user:password@hostname:port:db`, but it isn't working for me. However, `redis://user:password@hostname:port/db` does work. The difference is `/` between port and db.

The other configurations have worked perfectly for me.
